### PR TITLE
Potential fix for code scanning alert no. 1: Overly permissive regular expression range

### DIFF
--- a/test/fixtures/clean-snapshot.js
+++ b/test/fixtures/clean-snapshot.js
@@ -7,7 +7,7 @@ const cleanNewlines = (s) => s.replace(/\r\n/g, '\n')
 // ideally this could be avoided but its easier to just
 // run this command inside cleanSnapshot
 const normalizePath = (str) => cleanNewlines(str)
-  .replace(/[A-z]:\\/g, '\\') // turn windows roots to posix ones
+  .replace(/[A-Za-z]:\\/g, '\\') // turn windows roots to posix ones
   .replace(/\\+/g, '/') // replace \ with /
 
 const pathRegex = (p) => new RegExp(normalizePath(p), 'gi')


### PR DESCRIPTION
Potential fix for [https://github.com/Cunero/Cli.Cun/security/code-scanning/1](https://github.com/Cunero/Cli.Cun/security/code-scanning/1)

To resolve this issue, we must change the range from `[A-z]` to `[A-Za-z]`, ensuring only uppercase and lowercase English letters are included—that is, `A` through `Z` and `a` through `z`. This will precisely match valid Windows drive root letters and avoid matching the six ASCII characters between `Z` and `a`. Only the regular expression on line 10 of `test/fixtures/clean-snapshot.js` needs to be edited.

No new imports, methods, or variable definitions are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
